### PR TITLE
ユーザー情報に余分なスペース混入防止、設定ファイルショートカット追加

### DIFF
--- a/gaku-ura/conf/users.php
+++ b/gaku-ura/conf/users.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * gaku-ura9.5.13
+ * gaku-ura9.5.15
 */
 
 //ログイン必須とは限らない機能を考慮し、ログインチェックは初期化では行わない
@@ -104,7 +104,7 @@ class GakuUraUser{
 		$user_row = '';
 		foreach ($this->user_list_keys as $k){
 			if (isset($user_data[$k])){
-				$user_row .= $user_data[$k];
+				$user_row .= trim(self::h($user_data[$k]));
 			}
 			$user_row .= "\t";
 		}

--- a/gaku-ura/data/users/html/admin.html
+++ b/gaku-ura/data/users/html/admin.html
@@ -1,7 +1,7 @@
 <h1>{TITLE}</h1>
 
 <file_list>
-	<p><a href="?Menu=user">他のユーザーを管理</a></p>
+	<p><a href="?Menu=user">他のユーザーを管理</a> {CONFIG}</p>
 	<table border="1" width="100%">
 		<thead>
 			<tr style="text-align:left;"><th colspan="5">


### PR DESCRIPTION
ユーザー新規登録や変更で、名前やパスワードの前後にスペースが混入しないように対策しました。
ファイル管理機能のリンクに設定ファイル編集のショートカットを追加(編集可能なユーザーのみ)。
admin.htmlの{CONFIG}がそのリンクに置換されます。
