### PR TITLE
権限が無いのにrobots.txtなど作成防止

### DIFF
--- a/gaku-ura/main/users.php
+++ b/gaku-ura/main/users.php
@@ -225,7 +225,7 @@ function main(string $from):int{
 						exit;
 					} elseif ($_POST['new']==='/robots.txt' && strpos($conf->d_root, $c_root)!==false){
 						file_put_contents($conf->d_root.'/robots.txt', "User-agent: *\nSitemap : {$conf->domain}sitemap.xml\n", LOCK_EX);
-						header('Location:?'.str_replace($c_root,'',$conf->d_root).'&File=robots.txt&Menu=edit');
+						header('Location:?Dir='.str_replace($c_root,'',$conf->d_root).'&File=robots.txt&Menu=edit');
 						exit;
 					} elseif (not_empty($name) && !file_exists($current_dir.'/'.$name)){
 						if ($_POST['new'] === 'folder'){


### PR DESCRIPTION
管理ページのファイル管理機能について

ドキュメントルート直下に「robots.txt」や「sitemap.xml」を選択ボックスから作成するとき、その場所に権限がなくても作成出来てしまうバグを修正しました。
また、上限ディレクトリが「/」じゃない場合でも、そのときに編集画面に行けるようにリダイレクトURLを修正しました。