### PR TITLE
to_html関数を変更しました。tableタグを使うときにpタグで囲まないように変更。

### DIFF
--- a/gaku-ura/conf/conf.php
+++ b/gaku-ura/conf/conf.php
@@ -226,7 +226,7 @@ function list_isset(array $dict, array $keys):bool{
 //html互換md
 function to_html(string $md_text):string{
 	$fls = ['ol'=>0, 'ul'=>0];
-	$igtag = ['/','!','p','h','br','bl','bo','di','n','se','fo','ma','ar','as','sc','st','m','o','ul','l','dl','dd','dt'];
+	$igtag = ['/','!','p','t','h','br','bl','bo','di','n','se','fo','ma','ar','as','sc','st','m','o','ul','l','dl','dd','dt'];
 	$t = '';
 	foreach (explode("\n", u8lf($md_text)) as $i){
 		$row = trim($i);


### PR DESCRIPTION
gaku-ura/data/home/html 以下のmdファイルで、tableタグを使用するときにtable,trタグがpタグで囲まれないようにto_html関数のリストに「t」を追加しました。