### PR TITLE
ふりがなはコピペ対象外にする

### DIFF
--- a/gaku-ura/data/default/default.css
+++ b/gaku-ura/data/default/default.css
@@ -29,6 +29,9 @@ a[target]:after{
 	content:' >';
 	color:red;
 }
+rt{
+	user-select:none;
+}
 img, audio, video{
 	display:block;
 	margin:0;
@@ -105,3 +108,4 @@ nav label{
 }
 
 h1{color:#938;}
+


### PR DESCRIPTION
コピペするときに振り仮名が含まれると煩わしいのでセレクト出来なくする。