### PR TITLE
fix:ユーザーページcssのリンク色指定解除

### DIFF
--- a/gaku-ura/data/users/css/users.css
+++ b/gaku-ura/data/users/css/users.css
@@ -39,12 +39,4 @@ button:hover{
 .panel .side{
 	width:50%;
 }
-.panel a, .panel a:visited{
-	text-decoration:underline;
-	color:#15d;
-}
-.panel a:hover{
-	text-decoration:none;
-	font-weight:bold;
-}
 


### PR DESCRIPTION
背景がサイトによって違うので、サイト側のdefault.cssを適応するときにはgaku-uraでリンク色を指定するべきではない。
